### PR TITLE
fixed links in migrate instructions

### DIFF
--- a/docs/migrate/index.md
+++ b/docs/migrate/index.md
@@ -9,6 +9,6 @@ MrCode stores your settings at:
 
 Use the following scripts to migrate:
 
-- [Windows](./docs/migrate/windows.md)
-- [macOS](./docs/migrate/macos.md)
-- [Linux](./docs/migrate/linux.md)
+- [Windows](./windows.md)
+- [macOS](./macos.md)
+- [Linux](./linux.md)


### PR DESCRIPTION
Links redundantly referenced `/docs/migrate` as their target, which threw 404s.  And I hate github/s 404 lander.